### PR TITLE
common - Make aggCanvas::SuggestPixelFormat use a cfdg_ptr

### DIFF
--- a/src-common/aggCanvas.cpp
+++ b/src-common/aggCanvas.cpp
@@ -439,10 +439,10 @@ int     aggCanvas::cropY()          { return m->offsetY; }
 int     aggCanvas::cropWidth()      { return m->cropWidth; }
 int     aggCanvas::cropHeight()     { return m->cropHeight; }
 
-aggCanvas::PixelFormat aggCanvas::SuggestPixelFormat(CFDG* engine)
+aggCanvas::PixelFormat aggCanvas::SuggestPixelFormat(cfdg_ptr engine)
 {
-    if (engine == nullptr) 
-        return RGBA8_Blend;
+//    if (engine == nullptr) 
+//        return RGBA8_Blend;
     
     int ret = Gray8_Blend;
     

--- a/src-common/aggCanvas.h
+++ b/src-common/aggCanvas.h
@@ -60,7 +60,7 @@ class aggCanvas : public Canvas {
         bool colorCount256();
             // return whether the aggCanvas can fit in byte pixels
         
-        static PixelFormat SuggestPixelFormat(CFDG* engine);
+        static PixelFormat SuggestPixelFormat(cfdg_ptr engine);
         
     protected:
         aggCanvas(PixelFormat);

--- a/src-net/Document.cpp
+++ b/src-net/Document.cpp
@@ -1101,7 +1101,7 @@ void Document::DoRender()
         str.resize(bytes->Length);
         Marshal::Copy(bytes, 0, IntPtr(&str[0]), bytes->Length);
 
-        mAnimationCanvas = new ffCanvas(str.c_str(), WinCanvas::SuggestPixelFormat(mEngine->get()),
+        mAnimationCanvas = new ffCanvas(str.c_str(), WinCanvas::SuggestPixelFormat(mEngine),
             renderParams->animateWidth, renderParams->animateHeight,
             renderParams->frameRate, (ffCanvas::QTcodec)renderParams->codec);
 
@@ -1316,7 +1316,7 @@ void Document::setupCanvas(Renderer* r)
             renderParams->width : renderParams->animateWidth;
         int height = renderParams->action == RenderParameters::RenderActions::Render ?
             renderParams->height : renderParams->animateHeight;
-        mCanvas = new WinCanvas(mSystem, WinCanvas::SuggestPixelFormat(mEngine->get()), 
+        mCanvas = new WinCanvas(mSystem, WinCanvas::SuggestPixelFormat(mEngine), 
             width, height, (*mEngine)->getBackgroundColor());
     }
 }

--- a/src-unix/main.cpp
+++ b/src-unix/main.cpp
@@ -473,7 +473,7 @@ int main (int argc, char* argv[]) {
     }
 
     bool useRGBA = myDesign->usesColor;
-    aggCanvas::PixelFormat pixfmt = aggCanvas::SuggestPixelFormat(myDesign.get());
+    aggCanvas::PixelFormat pixfmt = aggCanvas::SuggestPixelFormat(myDesign);
     bool use16bit = (pixfmt & aggCanvas::Has_16bit_Color) != 0;
     const char* fmtnames[4] = { "PNG image", "SVG vector output", "Quicktime movie", "Wallpaper BMP image" };
     


### PR DESCRIPTION
At the moment, it uses a CFDG* rather than a cfdg_ptr. Everything else that calls it is just unwrapping the cfdg_ptr (typedef'd as a shared_ptr\<CFDG\>) and passing it in, so this makes it more consistent with the rest of the code.