### PR TITLE
Typo fixes "rotaion" --> "rotation"

### DIFF
--- a/input/lesson.cfdg
+++ b/input/lesson.cfdg
@@ -68,7 +68,7 @@ shape CHAPTER2
     SQUARE [ x 3 y 5 size 0.75 ]
 	// adjust size
 
-	// notice that rotaion and size
+	// notice that rotation and size
 	// are adjusted after location
 
     SQUARE [ x 5 y 5

--- a/input/lesson_v2.cfdg
+++ b/input/lesson_v2.cfdg
@@ -64,7 +64,7 @@ rule CHAPTER2 {
     SQUARE { x 3 y 5 size 0.75 }
 	// adjust size
 
-	// notice that rotaion and size
+	// notice that rotation and size
 	// are adjusted after location
 
     SQUARE { x 5 y 5


### PR DESCRIPTION
(Note: I haven't patched the same typos in `src-common/examples.h` which appears to be generated.)