### PR TITLE
Fix build for C++23

### DIFF
--- a/src-common/astexpression.cpp
+++ b/src-common/astexpression.cpp
@@ -1852,9 +1852,38 @@ namespace AST {
     {
         ent.append(entropyVal);
     }
-    
-    void
-    ASTstartSpecifier::entropy(std::string& ent) const
+
+    ASTstartSpecifier::~ASTstartSpecifier() = default;
+
+    ASTstartSpecifier::ASTstartSpecifier(
+        int t, const std::string& name, exp_ptr args, const yy::location& loc,
+        mod_ptr mod)
+        : ASTruleSpecifier(t, name, std::move(args), loc, nullptr)
+        , mModification(std::move(mod))
+    {
+    }
+
+    ASTstartSpecifier::ASTstartSpecifier(
+        int nameIndex, const std::string& name, const yy::location& loc, mod_ptr mod)
+        : ASTruleSpecifier(nameIndex, name, loc)
+        , mModification(std::move(mod))
+    {
+    }
+
+    ASTstartSpecifier::ASTstartSpecifier(
+        exp_ptr args, const yy::location& loc, mod_ptr mod)
+        : ASTruleSpecifier(std::move(args), loc)
+        , mModification(std::move(mod))
+    {
+    }
+
+    ASTstartSpecifier::ASTstartSpecifier(ruleSpec_ptr r, mod_ptr m) noexcept
+        : ASTruleSpecifier(std::move(r))
+        , mModification(std::move(m))
+    {
+    }
+
+    void ASTstartSpecifier::entropy(std::string& ent) const
     {
         ent.append(entropyVal);
         if (mModification)

--- a/src-common/astexpression.h
+++ b/src-common/astexpression.h
@@ -309,17 +309,15 @@ namespace AST {
     class ASTstartSpecifier final : public ASTruleSpecifier {
     public:
         mod_ptr mModification;
-        ASTstartSpecifier(int t, const std::string& name, exp_ptr args,
-                          const yy::location& loc, mod_ptr mod)
-        : ASTruleSpecifier(t, name, std::move(args), loc, nullptr),
-          mModification(std::move(mod)) { };
-        ASTstartSpecifier(int nameIndex, const std::string& name,
-                          const yy::location& loc, mod_ptr mod)
-        : ASTruleSpecifier(nameIndex, name, loc), mModification(std::move(mod)) { };
-        ASTstartSpecifier(exp_ptr args, const yy::location& loc, mod_ptr mod)
-        : ASTruleSpecifier(std::move(args), loc), mModification(std::move(mod)) { };
-        ASTstartSpecifier(ruleSpec_ptr r, mod_ptr m) noexcept
-        : ASTruleSpecifier(std::move(r)), mModification(std::move(m)) { };
+        ASTstartSpecifier(
+            int t, const std::string& name, exp_ptr args, const yy::location& loc,
+            mod_ptr mod);
+        ASTstartSpecifier(
+            int nameIndex, const std::string& name, const yy::location& loc,
+            mod_ptr mod);
+        ASTstartSpecifier(exp_ptr args, const yy::location& loc, mod_ptr mod);
+        ASTstartSpecifier(ruleSpec_ptr r, mod_ptr m) noexcept;
+        ~ASTstartSpecifier() override;
         void entropy(std::string& e) const final;
         ASTexpression* simplify(Builder* b) final;
         ASTexpression* compile(CompilePhase ph, Builder* b) final;


### PR DESCRIPTION
I'm embedding context-free as a library available in https://ossia.io for content generation. We are shifting from C++20 to C++23 and this uncovered a small build issue in this mode, where the unique_ptr in these function arguments now want to know the concrete type beforehand, forward declarations aren't enough anymore. Thus, move the implementation in the .cpp where it is visible.